### PR TITLE
Updated recipes to account for changes in Fleet

### DIFF
--- a/Fleet/fleetctl.download.recipe.yaml
+++ b/Fleet/fleetctl.download.recipe.yaml
@@ -10,6 +10,8 @@ Process:
     Arguments:
       github_repo: fleetdm/fleet
       asset_regex: fleetctl_v.*_macos.zip
+      sort_by_highest_tag_names: true
+      release_id: "latest"
 
   - Processor: com.github.jazzace.processors/TextSearcher
     Arguments:

--- a/Fleet/fleetctl.pkg.recipe.yaml
+++ b/Fleet/fleetctl.pkg.recipe.yaml
@@ -8,7 +8,6 @@ Input:
   PKGID: com.fleetdm.fleetctl
 
 Process:
-
   - Processor: PkgRootCreator
     Arguments:
       pkgdirs:
@@ -16,12 +15,12 @@ Process:
         usr/local: "0755"
         usr/local/bin: "0755"
       pkgroot: "%RECIPE_CACHE_DIR%/pkg_root"
-
+  
   - Processor: Copier
     Arguments:
-      source_path: "%RECIPE_CACHE_DIR%/%NAME%/%NAME%_v%version%_macos/fleetctl"
+      source_path: "%RECIPE_CACHE_DIR%/%NAME%/fleetctl_v%version%_macos_all/fleetctl"
       destination_path: "%RECIPE_CACHE_DIR%/pkg_root/usr/local/bin/fleetctl"
-
+  
   - Processor: PkgCreator
     Arguments:
       pkg_request:
@@ -30,7 +29,7 @@ Process:
             path: "/usr/local/bin/%NAME%"
             user: "root"
             mode: "0755"
-        pkgname: "%NAME%-%version%"
+        pkgname: "%NAME%_v%version%"
         version: "%version%"
         id: "%PKGID%"
         options: "purge_ds_store"

--- a/Fleet/fleetctl.pkg.recipe.yaml
+++ b/Fleet/fleetctl.pkg.recipe.yaml
@@ -8,6 +8,7 @@ Input:
   PKGID: com.fleetdm.fleetctl
 
 Process:
+
   - Processor: PkgRootCreator
     Arguments:
       pkgdirs:
@@ -15,12 +16,12 @@ Process:
         usr/local: "0755"
         usr/local/bin: "0755"
       pkgroot: "%RECIPE_CACHE_DIR%/pkg_root"
-  
+
   - Processor: Copier
     Arguments:
-      source_path: "%RECIPE_CACHE_DIR%/%NAME%/fleetctl_v%version%_macos_all/fleetctl"
+      source_path: "%RECIPE_CACHE_DIR%/%NAME%/%NAME%_v%version%_macos_all/fleetctl"
       destination_path: "%RECIPE_CACHE_DIR%/pkg_root/usr/local/bin/fleetctl"
-  
+
   - Processor: PkgCreator
     Arguments:
       pkg_request:
@@ -29,7 +30,7 @@ Process:
             path: "/usr/local/bin/%NAME%"
             user: "root"
             mode: "0755"
-        pkgname: "%NAME%_v%version%"
+        pkgname: "%NAME%-%version%"
         version: "%version%"
         id: "%PKGID%"
         options: "purge_ds_store"


### PR DESCRIPTION
- the zip file that is download now includes architecture information when uncompressed so the folder path changed from `fleetctl_v4.64.0_macos` to `fleetctl_v4.64.0_macos_all `
- updated the `GitHubReleasesInfoProvider` block to include `sort_by_highest_tag_names: true` and `release_id: "latest"` to help identify the right package when Fleet releases a version that is semantically older but is a newer release than the actual latest version available. Ex: v4.64.0 was released two days ago but a new package for v4.63.1 was released today.