### PR TITLE
Update fleetctl.pkg.recipe.yaml

### DIFF
--- a/Fleet/fleetctl.pkg.recipe.yaml
+++ b/Fleet/fleetctl.pkg.recipe.yaml
@@ -19,7 +19,7 @@ Process:
 
   - Processor: Copier
     Arguments:
-      source_path: "%RECIPE_CACHE_DIR%/%NAME%/%NAME%_v%version%_macos_all/fleetctl"
+      source_path: "%RECIPE_CACHE_DIR%/%NAME%/%NAME%_v%version%_macos/fleetctl"
       destination_path: "%RECIPE_CACHE_DIR%/pkg_root/usr/local/bin/fleetctl"
 
   - Processor: PkgCreator


### PR DESCRIPTION
Removing _all from the source path. This was a temporary implementation on the Fleet side for a specific version of fleetctl. 