### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Fleet/fleetctl.pkg.recipe.yaml
+++ b/Fleet/fleetctl.pkg.recipe.yaml
@@ -33,5 +33,4 @@ Process:
         pkgname: "%NAME%-%version%"
         version: "%version%"
         id: "%PKGID%"
-        options: "purge_ds_store"
         pkgdir: "%RECIPE_CACHE_DIR%"

--- a/Hashicorp/TerraformUniversal.pkg.recipe.yaml
+++ b/Hashicorp/TerraformUniversal.pkg.recipe.yaml
@@ -37,7 +37,6 @@ Process:
             path: usr/local/bin
             user: root
         id: 'com.hashicorp.terraform-arm64'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-arm64-%version%'
 
@@ -60,7 +59,6 @@ Process:
             path: usr/local/bin
             user: root
         id: 'com.hashicorp.terraform-amd64'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-amd64-%version%'
 
@@ -92,7 +90,6 @@ Process:
       pkg_request:
         id: 'com.hashicorp.terraform'
         version: '%version%'
-        options: purge_ds_store
         pkgname: '%NAME%-Universal-%version%'
         pkgdir: '%RECIPE_CACHE_DIR%'
         scripts: '%RECIPE_CACHE_DIR%/Universal/Scripts'

--- a/Ice/Ice.pkg.recipe.yaml
+++ b/Ice/Ice.pkg.recipe.yaml
@@ -31,5 +31,4 @@ Process:
         pkgname: "%NAME%-%version%"
         version: "%version%"
         id: "%PKGID%"
-        options: "purge_ds_store"
         pkgdir: "%RECIPE_CACHE_DIR%"

--- a/JoanConfigurator/JoanConfigurator.pkg.recipe.yaml
+++ b/JoanConfigurator/JoanConfigurator.pkg.recipe.yaml
@@ -34,7 +34,6 @@ Process:
             path: Applications
             user: root
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-arm64-%version%'
 
@@ -57,7 +56,6 @@ Process:
             path: Applications
             user: root
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-x86_64-%version%'
 
@@ -89,7 +87,6 @@ Process:
       pkg_request:
         id: '%bundleid%'
         version: '%version%'
-        options: purge_ds_store
         pkgname: '%NAME%-Universal-%version%'
         pkgdir: '%RECIPE_CACHE_DIR%'
         scripts: '%RECIPE_CACHE_DIR%/Universal/Scripts'

--- a/OldManYellsAt/OldManYellsAt.pkg.recipe.yaml
+++ b/OldManYellsAt/OldManYellsAt.pkg.recipe.yaml
@@ -33,5 +33,4 @@ Process:
         pkgname: "%NAME%-%ARCH%-%version%"
         version: "%version%"
         id: "%PKGID%"
-        options: "purge_ds_store"
         pkgdir: "%RECIPE_CACHE_DIR%"

--- a/flog/flog.pkg.recipe.yaml
+++ b/flog/flog.pkg.recipe.yaml
@@ -33,5 +33,4 @@ Process:
         pkgname: "%NAME%-%ARCH%-%version%"
         version: "%version%"
         id: "%PKGID%"
-        options: "purge_ds_store"
         pkgdir: "%RECIPE_CACHE_DIR%"

--- a/tofuutils/tenv.pkg.recipe.yaml
+++ b/tofuutils/tenv.pkg.recipe.yaml
@@ -79,5 +79,4 @@ Process:
         pkgname: "%NAME%-%ARCH%-%version%"
         version: "%version%"
         id: "%PKGID%"
-        options: "purge_ds_store"
         pkgdir: "%RECIPE_CACHE_DIR%"


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and remove the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._