### PR TITLE
Update fleetctl recipes

### DIFF
--- a/Fleet/fleetctl.download.recipe.yaml
+++ b/Fleet/fleetctl.download.recipe.yaml
@@ -1,6 +1,6 @@
 Description: Gets the latest version of fleetctl from Github releases, and normalises the version.
 Identifier: com.github.jc0b.download.fleetctl
-MinimumVersion: "2.3"
+MinimumVersion: "2.7.6"
 
 Input:
   NAME: fleetctl
@@ -13,11 +13,12 @@ Process:
       sort_by_highest_tag_names: true
       release_id: "latest"
 
-  - Processor: com.github.jazzace.processors/TextSearcher
+  - Processor: FindAndReplace
     Arguments:
-      re_pattern: \d+\.\d{1,2}\.\d{1,2}
-      text_in: "%version%"
-      result_output_var_name: "version"
+      find: fleet-v
+      input_string: "%version%"
+      replace: ""
+      result_output_var_name: version
 
   - Processor: URLDownloader
     Arguments:

--- a/Fleet/fleetctl.munki.recipe.yaml
+++ b/Fleet/fleetctl.munki.recipe.yaml
@@ -1,7 +1,7 @@
 Description: Gets the latest version of fleetctl, and imports it into Munki.
 Identifier: com.github.jc0b.munki.fleetctl
 ParentRecipe: com.github.jc0b.pkg.fleetctl
-MinimumVersion: "2.3"
+MinimumVersion: "2.7.6"
 
 Input:
   NAME: fleetctl
@@ -28,3 +28,9 @@ Process:
     Arguments:
       pkg_path: "%pkg_path%"
       repo_subdirectory: "%MUNKI_REPO_SUBDIR%"
+
+  - Processor: PathDeleter
+    Arguments:
+      path_list:
+        - "%RECIPE_CACHE_DIR%/%NAME%"
+        - "%RECIPE_CACHE_DIR%/pkg_root"

--- a/Fleet/fleetctl.pkg.recipe.yaml
+++ b/Fleet/fleetctl.pkg.recipe.yaml
@@ -1,7 +1,7 @@
 Description: Gets the latest version of fleetctl, and creates an installer pkg.
 Identifier: com.github.jc0b.pkg.fleetctl
 ParentRecipe: com.github.jc0b.download.fleetctl
-MinimumVersion: "2.3"
+MinimumVersion: "2.7.6"
 
 Input:
   NAME: fleetctl


### PR DESCRIPTION
This updates the fleetctl recipes to replace the third-party `com.github.jazzace.processors/TextSearcher` processor with the core `FindAndReplace` processor to remove the extra dependency.

It also adds some cleanup to the end of the Munki recipe.

-vv runs:
[download.log](https://github.com/user-attachments/files/23024568/download.log)
[pkg.log](https://github.com/user-attachments/files/23024569/pkg.log)
[munki.log](https://github.com/user-attachments/files/23024571/munki.log)
