### PR TITLE
Update Particulars.munki.recipe.yaml

### DIFF
--- a/Particulars/Particulars.munki.recipe.yaml
+++ b/Particulars/Particulars.munki.recipe.yaml
@@ -45,6 +45,7 @@ Process:
 
   - Processor: MunkiInstallsItemsCreator
     Arguments:
+      derive_minimum_os_version: true
       faux_root: "%RECIPE_CACHE_DIR%/payload"
       installs_item_paths:
         - "/Applications/Particulars.app"


### PR DESCRIPTION
This adds the `derive_minimum_os_version` so that it will be automatically populated in Munki.