### PR TITLE
Fix 404 download error for Visual Studio Code recipes

### DIFF
--- a/Microsoft/VisualStudioCode.download.recipe.yaml
+++ b/Microsoft/VisualStudioCode.download.recipe.yaml
@@ -3,29 +3,23 @@ Identifier: com.github.jc0b.download.VisualStudioCode
 MinimumVersion: "2.3"
 Input:
   NAME: VisualStudioCode
-  DOWNLOAD_ARCH: "" # leave blank for x86, needs to be "-arm64" for Apple Silicon. Can also be "-universal"
-  DOWNLOAD_URL: "https://code.visualstudio.com/sha/download?build=stable&os=darwin%DOWNLOAD_ARCH%"
+  DOWNLOAD_ARCH: "-x64" # needs to be "-arm64" for Apple Silicon. Can also be "-universal"
+  DOWNLOAD_URL: "https://code.visualstudio.com/sha/download?build=stable&os=darwin%DOWNLOAD_ARCH%-dmg"
 
 Process:
   - Processor: URLDownloader
     Arguments:
       url: "%DOWNLOAD_URL%"
-      filename: "%NAME%%DOWNLOAD_ARCH%.zip"
+      filename: "%NAME%%DOWNLOAD_ARCH%.dmg"
 
   - Processor: EndOfCheckPhase
 
-  - Processor: Unarchiver
-    Arguments:
-      archive_path: "%pathname%"
-      destination_path: "%RECIPE_CACHE_DIR%/%NAME%%DOWNLOAD_ARCH%"
-      purge_destination: true
-
   - Processor: CodeSignatureVerifier
     Arguments:
-      input_path: "%RECIPE_CACHE_DIR%/%NAME%%DOWNLOAD_ARCH%/Visual Studio Code.app"
+      input_path: "%RECIPE_CACHE_DIR%/downloads/%NAME%%DOWNLOAD_ARCH%.dmg/Visual Studio Code.app"
       requirement: identifier "com.microsoft.VSCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9
 
   - Processor: Versioner
     Arguments:
-      input_plist_path: "%RECIPE_CACHE_DIR%/%NAME%%DOWNLOAD_ARCH%/Visual Studio Code.app/Contents/Info.plist"
+      input_plist_path: "%RECIPE_CACHE_DIR%/downloads/%NAME%%DOWNLOAD_ARCH%.dmg/Visual Studio Code.app/Contents/Info.plist"
       plist_version_key: "CFBundleShortVersionString"

--- a/Microsoft/VisualStudioCode.munki.recipe.yaml
+++ b/Microsoft/VisualStudioCode.munki.recipe.yaml
@@ -5,7 +5,8 @@ MinimumVersion: "2.3"
 Input:
   NAME: VisualStudioCode
   DISPLAY_NAME: "VS Code"
-  MUNKI_ARCH: "x86_64" # override to arm64 for Apple Silicon
+  DOWNLOAD_ARCH: "-x64" # needs to be "-arm64" for Apple Silicon. Can also be "-universal"
+  MUNKI_ARCH: "x86_64" # override to arm64 for Apple Silicon. Delete supported_architectures for universal
   MUNKI_REPO_SUBDIR: "microsoft/visualstudiocode"
   pkginfo:
     catalogs:
@@ -19,19 +20,9 @@ Input:
       - "%MUNKI_ARCH%"
 
 Process:
-  - Processor: DmgCreator
-    Arguments:
-      dmg_path: "%RECIPE_CACHE_DIR%/%NAME%-%MUNKI_ARCH%.dmg"
-      dmg_root: "%RECIPE_CACHE_DIR%/%NAME%%DOWNLOAD_ARCH%"
 
   - Processor: MunkiImporter
     Arguments:
       extract_icon: true
-      pkg_path: "%dmg_path%"
+      pkg_path: "%pathname%"
       repo_subdirectory: "%MUNKI_REPO_SUBDIR%"
-
-  - Processor: PathDeleter
-    Arguments:
-      path_list:
-        - "%dmg_path%"
-        - "%dmg_root%"


### PR DESCRIPTION
## Issue addressed
Current implementation gives a 404 error:
```
autopkg run -v VisualStudioCode.munki.recipe.yaml
Processing VisualStudioCode.munki.recipe.yaml...
WARNING: VisualStudioCode.munki.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: ERROR: (56) The requested URL returned error: 404

curl: (56) The requested URL returned error: 404

Failed.
Receipt written to /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/receipts/VisualStudioCode.munki.recipe-receipt-20260209-094502.plist

The following recipes failed:
    VisualStudioCode.munki.recipe.yaml
        Error in com.github.jc0b.munki.VisualStudioCode: Processor: URLDownloader: Error: curl: (56) The requested URL returned error: 404

Nothing downloaded, packaged or imported.
```
## Details of PR
Seems the URL just had to be adjusted a bit, and it's already a .dmg, so no .dmg needs to be created.

### Note on Architecture
I don't love that the default is Intel, both because a universal binary is available and because Apple will stop supporting Intel as of macOS 27, but since it was previously blank for Intel, I didn't want to break anyone's flow who didn't have an override specifying a different architecture.

## Testing Done
### Universal
```
autopkg run -v com.github.jc0b.munki.VisualStudioCode
Processing com.github.jc0b.munki.VisualStudioCode...
WARNING: com.github.jc0b.munki.VisualStudioCode is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-universal.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-universal.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.pu6lbr/Visual Studio Code.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.pu6lbr/Visual Studio Code.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.pu6lbr/Visual Studio Code.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-universal.dmg
Versioner: Found version 1.109.0 in file /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-universal.dmg/Visual Studio Code.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /PATH/TO/MUNKI/REPO
MunkiImporter: Copied pkginfo to: /PATH/TO/MUNKI/REPO/pkgsinfo/microsoft/visualstudiocode/VisualStudioCode-1.109.0__2.plist
MunkiImporter:            pkg to: /PATH/TO/MUNKI/REPO/pkgs/microsoft/visualstudiocode/VisualStudioCode-universal-1.109.0.dmg
MunkiImporter:           icon to: /PATH/TO/MUNKI/REPO/icons/VisualStudioCode.png
Receipt written to /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/receipts/com.github.jc0b.munki-receipt-20260209-110629.plist

The following new items were imported into Munki:
    Name              Version  Catalogs  Pkginfo Path                                                  Pkg Repo Path                                                      Icon Repo Path        
    ----              -------  --------  ------------                                                  -------------                                                      --------------        
    VisualStudioCode  1.109.0  testing   microsoft/visualstudiocode/VisualStudioCode-1.109.0__2.plist  microsoft/visualstudiocode/VisualStudioCode-universal-1.109.0.dmg  VisualStudioCode.png  
```
### Silicon
```
autopkg run -v com.github.jc0b.munki.VisualStudioCode
Processing com.github.jc0b.munki.VisualStudioCode...
WARNING: com.github.jc0b.munki.VisualStudioCode is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 04 Feb 2026 02:52:47 GMT
URLDownloader: Storing new ETag header: "0xECCCE1DB18A4CE9A2A625C90B59C4C949467CF8E3A128F68AB9198E297C7E36F"
URLDownloader: Downloaded /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-arm64.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-arm64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.uhzJPs/Visual Studio Code.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.uhzJPs/Visual Studio Code.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.uhzJPs/Visual Studio Code.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-arm64.dmg
Versioner: Found version 1.109.0 in file /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-arm64.dmg/Visual Studio Code.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /PATH/TO/MUNKI/REPO
MunkiImporter: Copied pkginfo to: /PATH/TO/MUNKI/REPO/pkgsinfo/microsoft/visualstudiocode/VisualStudioCode-1.109.0__1.plist
MunkiImporter:            pkg to: /PATH/TO/MUNKI/REPO/pkgs/microsoft/visualstudiocode/VisualStudioCode-arm64-1.109.0.dmg
MunkiImporter:           icon to: /PATH/TO/MUNKI/REPO/icons/VisualStudioCode.png
Receipt written to /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/receipts/com.github.jc0b.munki-receipt-20260209-110542.plist

The following new items were downloaded:
    Download Path                                                                                                   
    -------------                                                                                                   
    /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-arm64.dmg  

The following new items were imported into Munki:
    Name              Version  Catalogs  Pkginfo Path                                                  Pkg Repo Path                                                  Icon Repo Path        
    ----              -------  --------  ------------                                                  -------------                                                  --------------        
    VisualStudioCode  1.109.0  testing   microsoft/visualstudiocode/VisualStudioCode-1.109.0__1.plist  microsoft/visualstudiocode/VisualStudioCode-arm64-1.109.0.dmg  VisualStudioCode.png 
```
### Intel
```
autopkg run -v com.github.jc0b.munki.VisualStudioCode
Processing com.github.jc0b.munki.VisualStudioCode...
WARNING: com.github.jc0b.munki.VisualStudioCode is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-x64.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-x64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.REbWzP/Visual Studio Code.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.REbWzP/Visual Studio Code.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.REbWzP/Visual Studio Code.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-x64.dmg
Versioner: Found version 1.109.0 in file /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/downloads/VisualStudioCode-x64.dmg/Visual Studio Code.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /PATH/TO/MUNKI/REPO
MunkiImporter: Copied pkginfo to: /PATH/TO/MUNKI/REPO/pkgsinfo/microsoft/visualstudiocode/VisualStudioCode-1.109.0.plist
MunkiImporter:            pkg to: /PATH/TO/MUNKI/REPO/pkgs/microsoft/visualstudiocode/VisualStudioCode-x64-1.109.0.dmg
MunkiImporter:           icon to: /PATH/TO/MUNKI/REPO/icons/VisualStudioCode.png
Receipt written to /Users/username/Library/AutoPkg/Cache/com.github.jc0b.munki.VisualStudioCode/receipts/com.github.jc0b.munki-receipt-20260209-110442.plist

The following new items were imported into Munki:
    Name              Version  Catalogs  Pkginfo Path                                               Pkg Repo Path                                                Icon Repo Path        
    ----              -------  --------  ------------                                               -------------                                                --------------        
    VisualStudioCode  1.109.0  testing   microsoft/visualstudiocode/VisualStudioCode-1.109.0.plist  microsoft/visualstudiocode/VisualStudioCode-x64-1.109.0.dmg  VisualStudioCode.png
```