### PR TITLE
Update VS Code recipes

### DIFF
--- a/Microsoft/VisualStudioCode.download.recipe.yaml
+++ b/Microsoft/VisualStudioCode.download.recipe.yaml
@@ -1,25 +1,31 @@
 Description: Downloads the latest VS code zip, based on an architecture you provide.
 Identifier: com.github.jc0b.download.VisualStudioCode
-MinimumVersion: "2.3"
+MinimumVersion: "2.7.6"
 Input:
+  ARCH: "arm64" # Intel = "x86_64", Apple Silicon = "arm64", Universal = "universal"
   NAME: VisualStudioCode
-  DOWNLOAD_ARCH: "-x64" # needs to be "-arm64" for Apple Silicon. Can also be "-universal"
-  DOWNLOAD_URL: "https://code.visualstudio.com/sha/download?build=stable&os=darwin%DOWNLOAD_ARCH%-dmg"
 
 Process:
+  - Processor: FindAndReplace
+    Arguments:
+      find: x86_64
+      input_string: "%ARCH%"
+      replace: x64
+      result_output_var_name: DOWNLOAD_ARCH
+
   - Processor: URLDownloader
     Arguments:
-      url: "%DOWNLOAD_URL%"
-      filename: "%NAME%%DOWNLOAD_ARCH%.dmg"
+      url: "https://code.visualstudio.com/sha/download?build=stable&os=darwin-%DOWNLOAD_ARCH%-dmg"
+      filename: "%NAME%-%ARCH%.dmg"
 
   - Processor: EndOfCheckPhase
 
   - Processor: CodeSignatureVerifier
     Arguments:
-      input_path: "%RECIPE_CACHE_DIR%/downloads/%NAME%%DOWNLOAD_ARCH%.dmg/Visual Studio Code.app"
+      input_path: "%pathname%/Visual Studio Code.app"
       requirement: identifier "com.microsoft.VSCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9
 
   - Processor: Versioner
     Arguments:
-      input_plist_path: "%RECIPE_CACHE_DIR%/downloads/%NAME%%DOWNLOAD_ARCH%.dmg/Visual Studio Code.app/Contents/Info.plist"
+      input_plist_path: "%pathname%/Visual Studio Code.app/Contents/Info.plist"
       plist_version_key: "CFBundleShortVersionString"

--- a/Microsoft/VisualStudioCode.munki.recipe.yaml
+++ b/Microsoft/VisualStudioCode.munki.recipe.yaml
@@ -1,28 +1,31 @@
-Description: Downloads the latest VS Code zip, and imports it into Munki.
+Description: Downloads the latest VS Code and imports it into Munki.
 Identifier: com.github.jc0b.munki.VisualStudioCode
 ParentRecipe: com.github.jc0b.download.VisualStudioCode
-MinimumVersion: "2.3"
+MinimumVersion: "2.7.6"
 Input:
+  ARCH: "arm64" # Intel = "x86_64", Apple Silicon = "arm64, Universal = "universal" || Delete the supported_architectures array if using "universal"
   NAME: VisualStudioCode
   DISPLAY_NAME: "VS Code"
-  DOWNLOAD_ARCH: "-x64" # needs to be "-arm64" for Apple Silicon. Can also be "-universal"
-  MUNKI_ARCH: "x86_64" # override to arm64 for Apple Silicon. Delete supported_architectures for universal
+  EXTRACT_ICON: "true" # Pass an empty variable to skip icon extraction.
+  MUNKI_CATEGORY: Development
   MUNKI_REPO_SUBDIR: "microsoft/visualstudiocode"
   pkginfo:
     catalogs:
       - testing
+    category: "%MUNKI_CATEGORY%"
     description: >
       Free and built on open source. Integrated Git, debugging and extensions.
     developer: Microsoft Corporation
     display_name: "%DISPLAY_NAME%"
     name: "%NAME%"
     supported_architectures:
-      - "%MUNKI_ARCH%"
+      - "%ARCH%"
+    unattended_install: true
+    unattended_uninstall: true
 
 Process:
-
   - Processor: MunkiImporter
     Arguments:
-      extract_icon: true
+      extract_icon: "%EXTRACT_ICON%"
       pkg_path: "%pathname%"
       repo_subdirectory: "%MUNKI_REPO_SUBDIR%"


### PR DESCRIPTION
The PR makes one crucial change, adds some admin choice and simplifies the recipes overall IMHO.

- Move the URL from the Input to the Process based on this conversation in Slack: https://macadmins.slack.com/archives/C056155B4/p1768935875961799

This change is needed so that any updates to the URL are automatically applied to everyone using these parent recipes.

With the URL as part of the input, changes made are not automatically applied downstream and users are required both to update trust and manually edit their override to include the upstream change.

- Consolidates the architecture into a single variable that can be used both for the download and for Munki. This is accomplished with the FindAndReplace processor.
- Switch to `%pathname%` in several places to be more resilient to future changes.
- Make Icon Extraction optional. This creates a variable that will only extract the icon if the admin requests it. (Defaults to true to preserve current behavior.)
- Adds the Munki category
- Adds unattended_install / _uninstall to the pkginfo

-vv runs attached
[universal.txt](https://github.com/user-attachments/files/25221732/universal.txt)
[x86_64.txt](https://github.com/user-attachments/files/25221733/x86_64.txt)
[arm64.txt](https://github.com/user-attachments/files/25221735/arm64.txt)
