### PR TITLE
Remove reliance on built-in FindAndReplace until 3.0 is released

### DIFF
--- a/Fleet/fleetctl.download.recipe.yaml
+++ b/Fleet/fleetctl.download.recipe.yaml
@@ -1,6 +1,6 @@
 Description: Gets the latest version of fleetctl from Github releases, and normalises the version.
 Identifier: com.github.jc0b.download.fleetctl
-MinimumVersion: "2.7.6"
+MinimumVersion: "2.3"
 
 Input:
   NAME: fleetctl
@@ -13,12 +13,15 @@ Process:
       sort_by_highest_tag_names: true
       release_id: "latest"
 
-  - Processor: FindAndReplace
+  - Processor: com.github.homebysix.FindAndReplace/FindAndReplace
     Arguments:
       find: fleet-v
       input_string: "%version%"
       replace: ""
-      result_output_var_name: version
+
+  - Processor: com.github.rtrouton.SharedProcessors/VariablePlaceholder
+    Arguments:
+      version: "%output_string%"
 
   - Processor: URLDownloader
     Arguments:

--- a/Gitlab/glab.download.recipe.yaml
+++ b/Gitlab/glab.download.recipe.yaml
@@ -7,12 +7,15 @@ Input:
   NAME: glab
 
 Process:
-  - Processor: FindAndReplace
+  - Processor: com.github.homebysix.FindAndReplace/FindAndReplace
     Arguments:
       find: x86_64
       input_string: "%ARCH%"
       replace: amd64
-      result_output_var_name: DOWNLOAD_ARCH
+
+  - Processor: com.github.rtrouton.SharedProcessors/VariablePlaceholder
+    Arguments:
+      DOWNLOAD_ARCH: "%output_string%"
 
   - Processor: com.github.n8felton.shared/GitLabReleasesInfoProvider
     Arguments:

--- a/Microsoft/VisualStudioCode.download.recipe.yaml
+++ b/Microsoft/VisualStudioCode.download.recipe.yaml
@@ -6,12 +6,15 @@ Input:
   NAME: VisualStudioCode
 
 Process:
-  - Processor: FindAndReplace
+  - Processor: com.github.homebysix.FindAndReplace/FindAndReplace
     Arguments:
       find: x86_64
       input_string: "%ARCH%"
       replace: x64
-      result_output_var_name: DOWNLOAD_ARCH
+
+  - Processor: com.github.rtrouton.SharedProcessors/VariablePlaceholder
+    Arguments:
+      DOWNLOAD_ARCH: "%output_string%"
 
   - Processor: URLDownloader
     Arguments:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # jc0b-recipes
 
 All recipes in this repository are in YAML format, and thus require at least [AutoPkg 2.3](https://github.com/autopkg/autopkg/releases/tag/v2.3).
+
+## License Notices
+The following Apache 2.0-licensed processors are used in the specified recipes:
+- [FindAndReplace](https://github.com/autopkg/homebysix-recipes/blob/master/FindAndReplace/FindAndReplace.py), written by [Elliot Jordan](https://github.com/homebysix).
+	- com.github.jc0b.download.fleetctl
+	- com.github.jc0b.download.glab
+	- com.github.jc0b.download.VisualStudioCode
+- [GitLabReleasesInfoProvider](https://github.com/autopkg/n8felton-recipes/blob/master/SharedProcessors/GitLabReleasesInfoProvider.py), written by [Nate Felton](https://github.com/n8felton).
+	- com.github.jc0b.download.glab
+- [HashiCorpURLProvider](https://github.com/autopkg/hjuutilainen-recipes/blob/master/SharedProcessors/HashiCorpURLProvider.py), written by [Hannes Juutilainen](https://github.com/hjuutilainen).
+	- com.github.jc0b.download.TerraformUniversal
+- [VariablePlaceholder](https://github.com/autopkg/rtrouton-recipes/blob/master/SharedProcessors/VariablePlaceholder.py), written by [Rich Trouton](https://github.com/rtrouton). 
+	- com.github.jc0b.download.fleetctl
+	- com.github.jc0b.download.glab
+	- com.github.jc0b.download.VisualStudioCode


### PR DESCRIPTION
Switches to using a combination of Elliot Jordan's FindAndReplace processor and Rich Trouton's VariablePlaceholder processor, instead of the FindAndReplace processor built-in to AutoPkg. This is a transition aid, so that folks using the AutoPkg 3.0 pre-releases can continue to use these recipes.