### PR TITLE
Switch to MacAdmins Open Source org

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.22.0
+    rev: v1.22.1
     hooks:
       - id: check-autopkg-recipes
         args: ["--recipe-prefix=com.github.jc0b.", "--strict", "--"]

--- a/Pique/Pique.download.recipe.yaml
+++ b/Pique/Pique.download.recipe.yaml
@@ -8,7 +8,7 @@ Input:
 Process:
   - Processor: GitHubReleasesInfoProvider
     Arguments:
-      github_repo: headmin/pique
+      github_repo: macadmins/pique
       asset_regex: Pique-.*pkg
       sort_by_highest_tag_names: true
       release_id: "latest"
@@ -38,7 +38,7 @@ Process:
   - Processor: CodeSignatureVerifier
     Arguments:
       expected_authority_names:
-        - "Developer ID Installer: Declarative IT GmbH (D6G4X4D7C9)"
+        - "Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)"
         - "Developer ID Certification Authority"
         - "Apple Root CA"
       input_path: "%pathname%"

--- a/Pique/Pique.munki.recipe.yaml
+++ b/Pique/Pique.munki.recipe.yaml
@@ -5,7 +5,7 @@ MinimumVersion: "2.7.6"
 
 Input:
   NAME: Pique
-  MUNKI_REPO_SUBDIR: "headmin/pique"
+  MUNKI_REPO_SUBDIR: "macadmins/pique"
   pkginfo:
     catalogs:
       - testing


### PR DESCRIPTION
Switches the recipe to:
- check the MAOS org instead of Henry's personal repo
- check for the MAOS package signature instead of Declarative IT

This doesn't need to be merged yet: only the pre-release requires this atm, but this is staged now to be ready :) 