### PR TITLE
Switch to MacAdmins Open Source for new releases

### DIFF
--- a/Contour/Contour.download.recipe.yaml
+++ b/Contour/Contour.download.recipe.yaml
@@ -8,7 +8,7 @@ Input:
 Process:
   - Processor: GitHubReleasesInfoProvider
     Arguments:
-      github_repo: headmin/contour
+      github_repo: macadmins/contour
       asset_regex: contour-.*pkg
       sort_by_highest_tag_names: true
       release_id: "latest"
@@ -38,7 +38,7 @@ Process:
   - Processor: CodeSignatureVerifier
     Arguments:
       expected_authority_names:
-        - "Developer ID Installer: Declarative IT GmbH (D6G4X4D7C9)"
+        - "Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)"
         - "Developer ID Certification Authority"
         - "Apple Root CA"
       input_path: "%pathname%"


### PR DESCRIPTION
Switched to MacAdmins Open Source. Let's not merge this until there is a version of Contour signed by MAOS on the MAOS repo.